### PR TITLE
Fixed an issue if the path didn't end with a slash

### DIFF
--- a/portablepy.ps1
+++ b/portablepy.ps1
@@ -14,6 +14,9 @@ if (!$destination) {
     $destination = '.\'
 }
 
+# Fixes an error if the user doesn't put a backslash at the end of the url
+$destination += "\"
+
 
 "You're installing $($pythonVersion) into $($destination)"
 


### PR DESCRIPTION
This pull request fixes an issue that occurred if the user didn't end the destination with a backslash
```diff
- The term '....\pythonpython.exe' is not recognized as the name of a cmdlet
```

This change works, as Windows treats slashes the same way it treats whitespaces _(removing empty elements)_, so it will result to a valid path regardless of how many slashes there are.